### PR TITLE
Pass entire array to pio, no only first element

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,4 +77,4 @@ runs:
         if [ -n "$verbose" ]; then args+=("--verbose"); fi
         if [ -n "$disable_auto_clean" ]; then args+=("--disable-auto-clean"); fi
 
-        echo $args | xargs pio run
+        echo ${args[*]} | xargs pio run


### PR DESCRIPTION
Right now only the first element of the array is passed via `echo` and `xargs` to `pio`. This means as soon as an environment is defined, for example the targets are not passed on anymore.

This PR changes the `echo` statement such that the entire array is printed and passed to `pio`.

Now any combination of environments and targets work as advertised and expected.